### PR TITLE
Always print SND_DEVICE_NONE

### DIFF
--- a/generate_acdb_data.sh
+++ b/generate_acdb_data.sh
@@ -8,6 +8,7 @@ echo "#define LIB_AUDIO_HAL \"$(basename $1)\"" >> acdb_data.h
 echo >> acdb_data.h
 
 echo "enum {" >> acdb_data.h
+echo "    SND_DEVICE_NONE = 0," >> acdb_data.h
 
 for device in $devices; do
     echo "    $device," >> acdb_data.h


### PR DESCRIPTION
Otherwise, the acdb_get tool would skip SND_DEVICE_OUT_HANDSET